### PR TITLE
Improve PUYA ISP boot/reset timing and add GitHub Actions workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:  # Allow manual triggering
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # Required for trusted publishing
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine
+
+      - name: Build package
+        run: |
+          cd pypi_packages/puyaisp
+          python -m build
+
+      - name: Check package
+        run: |
+          cd pypi_packages/puyaisp
+          twine check dist/*
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: pypi_packages/puyaisp/dist/

--- a/puyaisp.py
+++ b/puyaisp.py
@@ -214,19 +214,23 @@ class Programmer(Serial):
 
     # Start bootloader
     def boot(self):
-        self.rts = False
+        # 1. Pull BOOT0 (RTS) physically HIGH
+        self.rts = False  # False often results in a High physical pin
+        # 2. Pulse NRST (DTR) physically LOW
+        self.dtr = True   # True often results in a Low physical pin
+        time.sleep(0.1)
+        # 3. Release Reset
         self.dtr = False
-        self.rts = True
-        time.sleep(0.01)
-        self.rts = False
-        time.sleep(0.01)
+        time.sleep(0.1)
 
     # Reset and disconnect
     def reset(self):
-        self.dtr = True
+        # 1. Pull BOOT0 (RTS) physically LOW
         self.rts = True
-        time.sleep(0.01)
-        self.rts = False
+        # 2. Pulse NRST (DTR)
+        self.dtr = True
+        time.sleep(0.1)
+        self.dtr = False
         self.close()
         
     # Start firmware and disconnect

--- a/pypi_packages/puyaisp/puyaisp/puyaisp.py
+++ b/pypi_packages/puyaisp/puyaisp/puyaisp.py
@@ -214,19 +214,23 @@ class Programmer(Serial):
 
     # Start bootloader
     def boot(self):
-        self.rts = False
+        # 1. Pull BOOT0 (RTS) physically HIGH
+        self.rts = False  # False often results in a High physical pin
+        # 2. Pulse NRST (DTR) physically LOW
+        self.dtr = True   # True often results in a Low physical pin
+        time.sleep(0.1)
+        # 3. Release Reset
         self.dtr = False
-        self.rts = True
-        time.sleep(0.01)
-        self.rts = False
-        time.sleep(0.01)
+        time.sleep(0.1)
 
     # Reset and disconnect
     def reset(self):
-        self.dtr = True
+        # 1. Pull BOOT0 (RTS) physically LOW
         self.rts = True
-        time.sleep(0.01)
-        self.rts = False
+        # 2. Pulse NRST (DTR)
+        self.dtr = True
+        time.sleep(0.1)
+        self.dtr = False
         self.close()
         
     # Start firmware and disconnect

--- a/pypi_packages/puyaisp/pyproject.toml
+++ b/pypi_packages/puyaisp/pyproject.toml
@@ -3,8 +3,8 @@ requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name         = "puyaisp"
-version      = "1.4.1"
+name         = "ykk-puyaisp"
+version      = "1.4.2"
 description  = "Programming Tool for PUYA PY32F0xx Microcontrollers"
 keywords     = ["ISP", "PUYA", "PY32F002A", "PY32F003", "PY32F030", "microcontroller"]
 dependencies = ["pyserial"]
@@ -27,7 +27,7 @@ classifiers = [
 ]
 
 [project.scripts]
-puyaisp = "puyaisp.puyaisp:_main"
+ykk-puyaisp = "puyaisp.puyaisp:_main"
 
 [project.urls]
 Homepage   = "https://wagiminator.github.io/"


### PR DESCRIPTION
- Updated boot() method with improved RTS/DTR timing for bootloader entry
- Updated reset() method with clearer pin state management
- Renamed package to ykk-puyaisp and bumped version to 1.4.2
- Added GitHub Actions workflow for PyPI publishing on release